### PR TITLE
Fix: Ensure popup CSS is loaded by importing it in popup.ts

### DIFF
--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -1,3 +1,4 @@
+import './popup.css';
 import { getSettings, saveSettings } from '../shared/settings-manager';
 import type { Settings } from '../shared/content-processor';
 


### PR DESCRIPTION
The settings panel (which is part of popup.html) was missing its CSS styles because popup.css was not being processed by Vite during the build.

This was due to popup.css not being imported in its corresponding entry point, src/popup/popup.ts.

By adding `import './popup.css';` to src/popup/popup.ts, Vite now includes popup.css in the build, outputting it to dist/src/popup/popup.css where popup.html can correctly link to it.