### PR TITLE
Update npm scripts to use ts-node loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
   "type": "module",
   "scripts": {
     "dev": "vite build --watch",
-    "build": "node scripts/inline-build.ts",
+    "build": "node --no-warnings=ExperimentalWarning --loader=ts-node/esm scripts/inline-build.ts",
     "preview": "vite preview",
     "lint": "eslint . --ext .ts,.tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,html}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css,html}\"",
     "type-check": "tsc --noEmit",
-    "generate-icons": "ts-node scripts/generate-icons.ts",
+    "generate-icons": "node --no-warnings=ExperimentalWarning --loader=ts-node/esm scripts/generate-icons.ts",
     "clean": "rm -rf dist"
   },
   "dependencies": {


### PR DESCRIPTION
Update npm scripts to use ts-node loader

I'll modify the 'build' and 'generate-icons' scripts in package.json to execute TypeScript files directly using node with ts-node/esm loader. This change allows for a more direct way of running your TS scripts and suppresses experimental warnings.