### PR TITLE
Fix: Prevent Magic Copy on small non-text elements

### DIFF
--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -217,6 +217,35 @@ function handleMouseOver(event: MouseEvent): void {
 
   const tagName = targetElement.tagName.toLowerCase();
   if (HOVER_TARGET_TAGS.includes(tagName)) {
+    let width = 0;
+    let height = 0;
+
+    if (targetElement instanceof HTMLElement) {
+      width = targetElement.clientWidth;
+      height = targetElement.clientHeight;
+    } else if (targetElement instanceof SVGElement) {
+      const rect = targetElement.getBoundingClientRect();
+      width = rect.width;
+      height = rect.height;
+    } else {
+      // For other element types that might be in HOVER_TARGET_TAGS but are not HTMLElement or SVGElement
+      // (e.g. <canvas> which is an HTMLCanvasElement, a subtype of HTMLElement, so covered)
+      // We can use getBoundingClientRect as a fallback if needed, or assume they behave like HTMLElements.
+      // For now, this path is less likely given current HOVER_TARGET_TAGS.
+      const rect = targetElement.getBoundingClientRect();
+      width = rect.width;
+      height = rect.height;
+    }
+
+    if (width < 50 && height < 50) {
+      // If the element is too small, also ensure any existing button is hidden,
+      // especially if the mouse quickly moved from a valid target to a small icon.
+      if (currentTarget === targetElement) {
+           hideMagicCopy();
+      }
+      return; // Do not show Magic Copy for small elements
+    }
+
     // If a different Magic Copy is already shown (e.g. from a click), hide it first.
     // Or if it's the same target, this effectively refreshes its position if mouse moved significantly.
     if (currentTarget !== targetElement) {


### PR DESCRIPTION
Previously, Magic Copy would trigger on hover for all elements listed in HOVER_TARGET_TAGS, regardless of their size. This caused usability issues when small icons (like close buttons or dropdown arrows) were inadvertently covered by the Magic Copy button.

This change modifies the `handleMouseOver` function to check the dimensions of the target element. If the element is an HTMLElement and its clientWidth and clientHeight are both less than 50px, or if it's an SVGElement and its getBoundingClientRect width and height are both less than 50px, the Magic Copy button will not be shown. This prevents interference with small UI elements.