### PR TITLE
feat: 使交互模式的更改立即生效

### DIFF
--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -76,6 +76,23 @@
           </div>
         </div>
 
+        <!-- Interaction Mode Section -->
+        <div class="section">
+          <label class="section-title" data-i18n="interactionMode">Interaction Mode:</label>
+          <div class="radio-group">
+            <label class="radio-option">
+              <input type="radio" name="interactionMode" value="click" id="interaction-click" />
+              <span class="radio-custom"></span>
+              <span data-i18n="singleClick">Single-Click</span>
+            </label>
+            <label class="radio-option">
+              <input type="radio" name="interactionMode" value="dblclick" id="interaction-dblclick" />
+              <span class="radio-custom"></span>
+              <span data-i18n="doubleClick">Double-Click</span>
+            </label>
+          </div>
+        </div>
+
         <!-- Output Format Section -->
         <div class="section">
           <label class="section-title" data-i18n="outputFormat">Output Format:</label>

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -5,6 +5,8 @@ import { getSettings, saveSettings, type Settings } from '../shared/settings-man
 // DOM Elements
 interface PopupElements {
   enableMagicCopySwitch: HTMLInputElement; // Added this line
+  interactionClick: HTMLInputElement;
+  interactionDblClick: HTMLInputElement;
   formatMarkdown: HTMLInputElement;
   formatPlaintext: HTMLInputElement;
   attachTitle: HTMLInputElement;
@@ -20,6 +22,8 @@ let currentSettings: Settings;
 function getElements(): PopupElements {
   return {
     enableMagicCopySwitch: document.getElementById('enable-magic-copy-switch') as HTMLInputElement, // Added this line
+    interactionClick: document.getElementById('interaction-click') as HTMLInputElement,
+    interactionDblClick: document.getElementById('interaction-dblclick') as HTMLInputElement,
     formatMarkdown: document.getElementById('format-markdown') as HTMLInputElement,
     formatPlaintext: document.getElementById('format-plaintext') as HTMLInputElement,
     attachTitle: document.getElementById('attach-title') as HTMLInputElement,
@@ -72,6 +76,13 @@ function updateUIFromSettings(settings: Settings) {
   // Enable/Disable Magic Copy
   elements.enableMagicCopySwitch.checked = settings.isMagicCopyEnabled; // Added this line
 
+  // Interaction mode
+  if (settings.interactionMode === 'click') {
+    elements.interactionClick.checked = true;
+  } else {
+    elements.interactionDblClick.checked = true;
+  }
+
   // Output format
   if (settings.outputFormat === 'markdown') {
     elements.formatMarkdown.checked = true;
@@ -92,6 +103,7 @@ function updateUIFromSettings(settings: Settings) {
 function getSettingsFromUI(): Partial<Settings> {
   return {
     isMagicCopyEnabled: elements.enableMagicCopySwitch.checked, // Added this line
+    interactionMode: elements.interactionClick.checked ? 'click' : 'dblclick',
     outputFormat: elements.formatMarkdown.checked ? 'markdown' : 'plaintext',
     attachTitle: elements.attachTitle.checked,
     attachURL: elements.attachURL.checked
@@ -120,6 +132,10 @@ async function saveCurrentSettings() {
  * Setup event listeners for form elements
  */
 function setupEventListeners() {
+  // Interaction mode radio buttons
+  elements.interactionClick.addEventListener('change', saveCurrentSettings);
+  elements.interactionDblClick.addEventListener('change', saveCurrentSettings);
+
   // Output format radio buttons
   elements.formatMarkdown.addEventListener('change', saveCurrentSettings);
   elements.formatPlaintext.addEventListener('change', saveCurrentSettings);

--- a/src/shared/settings-manager.ts
+++ b/src/shared/settings-manager.ts
@@ -5,6 +5,7 @@ export interface Settings {
   attachTitle: boolean;
   attachURL: boolean;
   language: 'system' | 'en' | 'zh';
+  interactionMode: 'click' | 'dblclick';
 }
 
 export const SETTINGS_KEY = 'copilot_settings';
@@ -14,7 +15,8 @@ export const DEFAULT_SETTINGS: Settings = {
   outputFormat: 'markdown',
   attachTitle: false,
   attachURL: false,
-  language: 'system'
+  language: 'system',
+  interactionMode: 'dblclick'
 };
 
 export function getSystemLanguage(): 'system' | 'en' | 'zh' {


### PR DESCRIPTION
- 更新了 `storage.onChanged` 监听器，以确保在设置更改后，交互模式能够立即在当前页面上生效，而无需刷新页面。