### PR TITLE
fix(popup): 修复浅色主题下部分文字颜色问题

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -259,7 +259,6 @@ body {
 
 .switch-label {
   font-size: 14px; /* Matches general font size */
-  color: #ffffff; /* Changed to white color */
   /* If you want it to behave like .checkbox-option text, ensure padding and alignment match */
 }
 


### PR DESCRIPTION
移除了 .switch-label 中硬编码的白色颜色，使其能够继承父级样式，从而在浅色主题（如Light Chrome）中正常显示。