### PR TITLE
修复：调整弹出设置面板的CSS样式以适应不同的语言环境

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -59,7 +59,7 @@ body {
 
 /* Form Sections */
 #settings-form {
-  padding: 20px;
+  padding: 10px;
 }
 
 .section {
@@ -145,6 +145,7 @@ body {
   align-items: center;
   gap: 8px;
   cursor: pointer;
+  padding: 6px;
   border-radius: 8px;
   transition: background-color 0.2s ease;
   flex: 1; /* Allow items to grow */
@@ -216,7 +217,7 @@ body {
 /* Footer */
 .footer {
   background-color: #f9fafb;
-  padding: 16px 20px;
+  padding: 6px 10px;
   border-top: 1px solid #e5e7eb;
 }
 
@@ -383,8 +384,7 @@ input:checked + .slider:before {
   font-weight: 600;
   color: #111827;
   font-size: 14px;
-  max-width: 80px;
-  min-width: 50px;
+  width: 60px;
   flex-shrink: 0;
 }
 
@@ -452,6 +452,15 @@ input:checked + .slider:before {
 }
 
 /* Dark mode support (if needed) */
+/* Style adjustments for English version */
+:lang(en) {
+  body {
+    font-size: 12px;
+  }
+  .radio-option {
+    padding: 6px;
+  }
+}
 @media (prefers-color-scheme: dark) {
   body {
     background: #111827;


### PR DESCRIPTION
- 在英文环境下，将字体大小调整为12px，并调整了选项的内边距。
- 统一了内联标题的宽度，并删除了最大/最小宽度限制。
- 调整了复选框选项、表单和页脚的内边距。