### PR TITLE
fix: 修复鼠标移出图片后边框不消失的问题

### DIFF
--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -580,7 +580,7 @@ function handleMouseOut(event: MouseEvent): void {
   }
 
   // If the mouse is moving to a child of the currentTarget, don't hide.
-  if (currentTarget.contains(relatedTarget)) {
+  if (currentTarget.contains(relatedTarget) && relatedTarget !== document.body && relatedTarget !== document.documentElement) {
     return;
   }
 


### PR DESCRIPTION
在 `handleMouseOut` 函数中，当鼠标从图片快速移动到页面空白区域时，`relatedTarget` 可能是 `<body>` 或 `<html>`。

在这种情况下，`currentTarget.contains(relatedTarget)` 会返回 `true`，导致 `hideMagicCopy()` 不会被调用，边框和按钮也就不会消失。

通过在 `currentTarget.contains(relatedTarget)` 的判断条件中增加对 `relatedTarget` 是否为 `<body>` 或 `<html>` 的判断，可以解决该问题。