### PR TITLE
fix(settings): Ensure settings changes take effect immediately

### DIFF
--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -618,8 +618,8 @@ async function initializeContentScript(): Promise<void> {
     // Listen for settings changes from the popup/options page.
     if (chrome.storage && chrome.storage.onChanged) {
       chrome.storage.onChanged.addListener((changes, areaName) => {
-        // @ts-ignore: SETTINGS_KEY, getSystemLanguage are from inlined settings-manager.ts
-        if (areaName === 'local' && changes[SETTINGS_KEY]) {
+        // @ts-ignore: SETTINGS_KEY is available from inlined settings-manager.ts
+        if (areaName === 'sync' && changes[SETTINGS_KEY]) {
           const oldSettings = userSettings ? { ...userSettings } : null;
           // @ts-ignore: SETTINGS_KEY is available from inlined settings-manager.ts
           const newSettingsValue = changes[SETTINGS_KEY].newValue as Settings;
@@ -629,8 +629,11 @@ async function initializeContentScript(): Promise<void> {
             // @ts-ignore
             newSettingsValue.language = getSystemLanguage();
           }
+
           userSettings = newSettingsValue;
           console.debug('AI Copilot: Settings updated through storage listener.', userSettings);
+          console.debug('AI Copilot: Table output format is now:', userSettings?.tableOutputFormat);
+
 
           // Check if the isMagicCopyEnabled setting has changed
           if (oldSettings?.isMagicCopyEnabled !== userSettings.isMagicCopyEnabled) {
@@ -639,12 +642,6 @@ async function initializeContentScript(): Promise<void> {
             } else {
               disableMagicCopyFeatures();
             }
-          }
-
-          // Check if the interactionMode has changed
-          if (oldSettings?.interactionMode !== userSettings.interactionMode) {
-            // No need to enable/disable features, just log the change
-            console.debug('AI Copilot: Interaction mode changed to', userSettings.interactionMode);
           }
         }
       });


### PR DESCRIPTION
The content script was not listening for `chrome.storage.onChanged` events correctly. It was listening for changes in the `local` storage area, but the settings were being saved to the `sync` storage area.

This caused a situation where changes made in the settings panel (e.g., changing the table output format) would not take effect in the content script until the page was reloaded.

The fix involves changing the `areaName` in the `chrome.storage.onChanged` listener from `local` to `sync` in `src/content/content.ts`. This ensures that the content script's settings cache is updated in real-time whenever you change a setting, making for a more intuitive user experience.